### PR TITLE
Add support for GETTING_STARTED notebook

### DIFF
--- a/zfs-homedir.sh
+++ b/zfs-homedir.sh
@@ -45,6 +45,11 @@ main() {
     else
         echo "Creating Homedir: ${homedir}"
         zfs create ${ZFSOPTS} ${homefs}
+
+        if [ -n "${GETTING_STARTED-}" ]; then
+            wget "${GETTING_STARTED}" -O "${homedir}/getting-started.ipynb"
+        fi
+
         chown -R ${owner}:${owner} ${homedir}
     fi
 }


### PR DESCRIPTION
If the `GETTING_STARTED` environment variable is set, the value (which should be a URL to a notebook) will be downloaded to the user's home directory when the home directory is initially created.