### PR TITLE
Updating shib for JupyterHub 1.0.0 compatibility

### DIFF
--- a/syzygyauthenticator/shib.py
+++ b/syzygyauthenticator/shib.py
@@ -9,7 +9,7 @@ class RemoteUserLoginHandler(BaseHandler):
 
     async def get(self):
         self.statsd.incr('login.request')
-        user = self.get_current_user()
+        user = await self.get_current_user()
 
         if user:
             self.set_login_cookie(user)
@@ -35,7 +35,7 @@ class RemoteUserLogoutHandler(BaseHandler):
         shibReturnURL = self.authenticator.shibReturnURL
         if shibReturnURL != "":
             shibLogoutURL = "%s?return=%s" % (shibLogoutURL, shibReturnURL)
-        
+
         self.clear_login_cookie()
 
         self.log.info("Logout dest: %s" % shibLogoutURL)


### PR DESCRIPTION
@ianabc I ran into this issue while testing the 0.9.6 to 1.0.0 upgrade process. Logging in with SimpleSAMLphp enabled wouldn't work unless I made this change.

The error prior to this change is:

```
', remote_ip='127.0.0.1')
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: Traceback (most recent call last):
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: File "/usr/local/lib64/python3.6/site-packages/tornado/web.py", line 1699, in _execute
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: result = await result
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: File "/usr/local/lib/python3.6/site-packages/syzygyauthenticator/shib.py", line 15, in get
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: self.set_login_cookie(user)
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: File "/usr/local/lib/python3.6/site-packages/jupyterhub/handlers/base.py", line 538, in set_login_cookie
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: self.set_hub_cookie(user)
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: File "/usr/local/lib/python3.6/site-packages/jupyterhub/handlers/base.py", line 518, in set_hub_cookie
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: self._set_user_cookie(user, self.hub)
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: File "/usr/local/lib/python3.6/site-packages/jupyterhub/handlers/base.py", line 482, in _set_user_cookie
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: self.log.debug("Setting cookie for %s: %s", user.name, server.cookie_name)
Jan 21 19:47:41 hub-prompt-reindeer jupyterhub: AttributeError: 'coroutine' object has no attribute 'name'
```

Have you seen this error before and have you worked around it with an alternative fix?